### PR TITLE
Run Angular Update GH Actions job only on this org

### DIFF
--- a/.github/workflows/ngx-uptodate.yml
+++ b/.github/workflows/ngx-uptodate.yml
@@ -6,6 +6,7 @@ on: # when the action should run. Can also be a CRON or in response to external 
 jobs:
   ngxUptodate:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'UMM-CSci-3601'
     steps:
       - name: Updating ng dependencies # the magic happens here!
         uses: tinesoft/ngx-uptodate@v1.1.1


### PR DESCRIPTION
This prevents it from running on student repos created from it.

I don't know if this is desired functionality but I thought I'd suggest it.