### PR TITLE
Specify that Java source files are written in UTF-8

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -81,3 +81,8 @@ jacocoTestReport {
     html.destination file("${buildDir}/jacocoHtml")
   }
 }
+
+tasks.withType(JavaCompile) {
+  // All of our source files are written in UTF-8
+  options.encoding = 'UTF-8'
+}


### PR DESCRIPTION
cf. UMM-CSci-3601-S21/intro-to-git-S21#29

> Previously, we weren't telling Gradle what encoding we're using for our Java files, so Gradle was just guessing. (On *nix, it was guessing UTF-8, but on Windows, it was guessing Windows-1252.) This meant that on Windows, any non-ASCII characters got misinterpreted (which lead to failing tests).
> 
> @floogulinc noticed that there are also some issues with the encoding Java uses to print non-ASCII characters. That's its own separate issue, though—and one beyond the scope of this pull request. 🙂

Closes #290