### PR TITLE
Interpret the "company" query param as a literal string, not as a regex

### DIFF
--- a/server/src/main/java/umm3601/user/UserController.java
+++ b/server/src/main/java/umm3601/user/UserController.java
@@ -10,6 +10,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import com.google.common.collect.ImmutableMap;
 import com.mongodb.client.MongoCollection;
@@ -93,7 +94,7 @@ public class UserController {
     }
 
     if (ctx.queryParamMap().containsKey("company")) {
-      filters.add(regex("company", ctx.queryParam("company"), "i"));
+      filters.add(regex("company", Pattern.quote(ctx.queryParam("company")), "i"));
     }
 
     if (ctx.queryParamMap().containsKey("role")) {


### PR DESCRIPTION
Just a quick change. Right now, if you request `/api/users?company=.*` you get all the users, because the string `".*"` is injected directly into the regex query. (The query ends up looking like this: `/.*/i`). It would be a bit nicer if we escape the value we get from the query param first (so that the query ends up looking like this: `/\.\*/i`)

This isn't a huge deal, given that I don't think the `company=` query parameter is actually used at the moment. Still, I wanted to make a note of it.

Oh, incidentally, it seems like there are [fancier ways of doing case-insensitive queries in Mongo](https://docs.mongodb.com/manual/core/index-text/#case-insensitivity), but they all involve creating indices in the database, which we haven't been doing. 🙂