### PR TITLE
Spring 2021 GitHub Actions updates

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -2,6 +2,10 @@ name: Client
 
 on: [push]
 
+defaults:
+  run:
+    working-directory: ./client
+
 jobs:
   ng-test:
     runs-on: ubuntu-latest
@@ -25,11 +29,9 @@ jobs:
 
     - name: Install dependencies (npm ci)
       run: npm ci
-      working-directory: ./client
 
     - name: Test (npm run test)
       run: npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
-      working-directory: ./client
 
   ng-lint:
     runs-on: ubuntu-latest
@@ -53,8 +55,6 @@ jobs:
 
     - name: Install dependencies (npm ci)
       run: npm ci
-      working-directory: ./client
 
     - name: Lint (npm run lint)
       run: npm run lint
-      working-directory: ./client

--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -1,16 +1,16 @@
-name: Client Angular
+name: Client
 
 on: [push]
 
 jobs:
   ng-test:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout repository
+      uses: actions/checkout@v2
 
-    - name: Cache node modules
+    - name: Cache Node modules
       uses: actions/cache@v2
       with:
         path: ~/.npm
@@ -26,16 +26,19 @@ jobs:
     - name: Install dependencies (npm ci)
       run: npm ci
       working-directory: ./client
+
     - name: Test (npm run test)
       run: npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
       working-directory: ./client
 
   ng-lint:
     runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
 
-    - name: Cache node modules
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Cache Node modules
       uses: actions/cache@v2
       with:
         path: ~/.npm

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,10 +1,9 @@
-name: End-to-End
+name: End to End
 
 on: [push]
 
 jobs:
   ng-e2e:
-
     runs-on: ubuntu-latest
 
     services:
@@ -14,7 +13,7 @@ jobs:
           - '27017-27019:27017-27019'
 
     steps:
-    - name: Checkout the repository
+    - name: Checkout repository
       uses: actions/checkout@v2
 
     - name: Seed database

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -1,10 +1,9 @@
-name: Server Java
+name: Server
 
 on: [push]
 
 jobs:
   gradle-build:
-
     runs-on: ubuntu-latest
 
     services:
@@ -14,7 +13,7 @@ jobs:
           - '27017-27019:27017-27019'
 
     steps:
-    - name: Checkout the repository
+    - name: Checkout repository
       uses: actions/checkout@v2
 
     - name: Cache Gradle artifacts (downloaded JARs, the wrapper, and any downloaded JDKs)

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 > dealt with that.
 # CSCI 3601 Iteration Template
 
-[![Server Build Status](../../workflows/Server%20Java/badge.svg)](../../actions?query=workflow%3A"Server+Java")
-[![Client Build Status](../../workflows/Client%20Angular/badge.svg)](../../actions?query=workflow%3A"Client+Angular")
-[![End to End Build Status](../../workflows/End-to-End/badge.svg)](../../actions?query=workflow%3AEnd-to-End)
+[![Server Build Status](../../actions/workflows/server.yml/badge.svg)](../../actions/workflows/server.yml)
+[![Client Build Status](../../actions/workflows/client.yaml/badge.svg)](../../actions/workflows/client.yaml)
+[![End to End Build Status](../../actions/workflows/e2e.yaml/badge.svg)](../../actions/workflows/e2e.yaml)
 
 [![BCH compliance](https://bettercodehub.com/edge/badge/UMM-CSci-3601/3601-iteration-template?branch=master)](https://bettercodehub.com/)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/UMM-CSci-3601/3601-iteration-template.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/UMM-CSci-3601/3601-iteration-template/alerts/)


### PR DESCRIPTION
Just a bunch of small updates to the GitHub Actions workflows including:
- Renaming the `yml` files for simplicity and clarity
  - They are just `server.yml`, `client.yml`, and `e2e.yml` now
- Renaming the workflows themselves similarly
  - They are now "Server", "Client", and "End to End"
- Updating the badges in the README. Closes #314 