### PR TITLE
Clean up the use of regexes for validation on the client-side

### DIFF
--- a/client/src/app/users/add-user.component.html
+++ b/client/src/app/users/add-user.component.html
@@ -23,10 +23,7 @@ is potentially helpful and contributed to the shaping of this example -->
 
           <mat-form-field>
             <mat-label>Age</mat-label>
-            <!-- We'd use type="number" here, but then the field would add some
-            of its own validation, which interferes with what we're doing. -->
-            <input matInput #input id="ageField" placeholder="Age"
-                  formControlName="age" required>
+            <input matInput #input type = "number" id="ageField" placeholder="Age"                  formControlName="age" required>
             <mat-error *ngFor="let validation of addUserValidationMessages.age">
               <mat-error class="error-message" id="age-error"
                         *ngIf="addUserForm.get('age').hasError(validation.type) && (addUserForm.get('age').dirty || addUserForm.get('age').touched)">

--- a/client/src/app/users/add-user.component.html
+++ b/client/src/app/users/add-user.component.html
@@ -23,7 +23,8 @@ is potentially helpful and contributed to the shaping of this example -->
 
           <mat-form-field>
             <mat-label>Age</mat-label>
-            <input matInput #input type = "number" id="ageField" placeholder="Age"                  formControlName="age" required>
+            <input matInput #input type="number" id="ageField" placeholder="Age"
+                  formControlName="age" required>
             <mat-error *ngFor="let validation of addUserValidationMessages.age">
               <mat-error class="error-message" id="age-error"
                         *ngIf="addUserForm.get('age').hasError(validation.type) && (addUserForm.get('age').dirty || addUserForm.get('age').touched)">

--- a/client/src/app/users/add-user.component.html
+++ b/client/src/app/users/add-user.component.html
@@ -23,7 +23,7 @@ is potentially helpful and contributed to the shaping of this example -->
 
           <mat-form-field>
             <mat-label>Age</mat-label>
-            <input matInput #input id="ageField" type="number" placeholder="Age"
+            <input matInput #input id="ageField" placeholder="Age"
                   formControlName="age" required>
             <mat-error *ngFor="let validation of addUserValidationMessages.age">
               <mat-error class="error-message" id="age-error"

--- a/client/src/app/users/add-user.component.html
+++ b/client/src/app/users/add-user.component.html
@@ -23,6 +23,8 @@ is potentially helpful and contributed to the shaping of this example -->
 
           <mat-form-field>
             <mat-label>Age</mat-label>
+            <!-- We'd use type="number" here, but then the field would add some
+            of its own validation, which interferes with what we're doing. -->
             <input matInput #input id="ageField" placeholder="Age"
                   formControlName="age" required>
             <mat-error *ngFor="let validation of addUserValidationMessages.age">

--- a/client/src/app/users/add-user.component.spec.ts
+++ b/client/src/app/users/add-user.component.spec.ts
@@ -166,7 +166,7 @@ describe('AddUserComponent', () => {
       expect(ageControl.hasError('max')).toBeTruthy();
     });
 
-    it('should not allow an age to contain non-digits', () => {
+    it('should not allow an age to be non-numeric', () => {
       // The HTML input field itself checks to make sure that the value is
       // numeric. Angular's form controls aren't even involved with this step.
       const ageHtmlInput =
@@ -174,6 +174,12 @@ describe('AddUserComponent', () => {
       ageHtmlInput.value = '27aa';
       expect(ageHtmlInput.validity.valid).toBeFalsy();
       expect(ageHtmlInput.validity.valueMissing).toBeTruthy();
+    });
+
+    it('should not allow an age to contain a decimal point', () => {
+      ageControl.setValue(27.5);
+      expect(ageControl.valid).toBeFalsy();
+      expect(ageControl.hasError('pattern')).toBeTruthy();
     });
   });
 

--- a/client/src/app/users/add-user.component.spec.ts
+++ b/client/src/app/users/add-user.component.spec.ts
@@ -117,66 +117,76 @@ describe('AddUserComponent', () => {
   });
 
   describe('The age field', () => {
-    let ageControl: AbstractControl;
-
-    beforeEach(() => {
-      ageControl = addUserComponent.addUserForm.controls.age;
-    });
-
-    it('should not allow empty ages', () => {
-      ageControl.setValue('');
-      expect(ageControl.valid).toBeFalsy();
-    });
-
-    describe('should be fine with "27"', () => {
-      // Both the form control and the HTML itself enforce certain constraints
-      // on what we can put in the age field. The HTML makes sure that the
-      // value is numeric, and the form control makes sure that it's in the
-      // right range.
-      it('...the form control', () => {
-        ageControl.setValue('27');
-        expect(ageControl.valid).toBeTruthy();
+    // Both the form control and the HTML itself enforce certain constraints
+    // on what we can put in the age field. The HTML makes sure that the
+    // value is numeric, and the form control makes sure that it's in the
+    // right range.
+    describe('The HTML element', () => {
+      it('should not allow empty ages', () => {
+        const ageHtmlInput =
+          document.getElementsByTagName('input').namedItem('ageField');
+        ageHtmlInput.value = '';
+        expect(ageHtmlInput.validity.valid).toBeFalsy();
+        expect(ageHtmlInput.validity.valueMissing).toBeTruthy();
       });
 
-      it('...and the input field itself', () => {
+      it('should be fine with "27"', () => {
         const ageHtmlInput =
           document.getElementsByTagName('input').namedItem('ageField');
         ageHtmlInput.value = '27';
         expect(ageHtmlInput.validity.valid).toBeTruthy();
       });
+
+      it('should not allow an age to be non-numeric', () => {
+        // The HTML input field itself checks to make sure that the value is
+        // numeric. Angular's form controls aren't even involved with this step.
+        const ageHtmlInput =
+          document.getElementsByTagName('input').namedItem('ageField');
+        ageHtmlInput.value = '27aa';
+        expect(ageHtmlInput.validity.valid).toBeFalsy();
+        expect(ageHtmlInput.validity.valueMissing).toBeTruthy();
+      });
     });
 
-    it('should fail on ages that are too low', () => {
-      ageControl.setValue('14');
-      expect(ageControl.valid).toBeFalsy();
-      expect(ageControl.hasError('min')).toBeTruthy();
-    });
+    describe('The Angular form control', () => {
+      let ageControl: AbstractControl;
 
-    // In the real world, you'd want to be pretty careful about
-    // setting upper limits on things like ages.
-    it('should fail on ages that are too high', () => {
-      ageControl.setValue(201);
-      expect(ageControl.valid).toBeFalsy();
-      // I have no idea why I have to use a lower case 'l' here
-      // when it's an upper case 'L' in `Validators.maxLength(2)`.
-      // But I apparently do.
-      expect(ageControl.hasError('max')).toBeTruthy();
-    });
+      beforeEach(() => {
+        ageControl = addUserComponent.addUserForm.controls.age;
+      });
 
-    it('should not allow an age to be non-numeric', () => {
-      // The HTML input field itself checks to make sure that the value is
-      // numeric. Angular's form controls aren't even involved with this step.
-      const ageHtmlInput =
-        document.getElementsByTagName('input').namedItem('ageField');
-      ageHtmlInput.value = '27aa';
-      expect(ageHtmlInput.validity.valid).toBeFalsy();
-      expect(ageHtmlInput.validity.valueMissing).toBeTruthy();
-    });
+      it('should not allow empty ages', () => {
+        ageControl.setValue('');
+        expect(ageControl.valid).toBeFalsy();
+      });
 
-    it('should not allow an age to contain a decimal point', () => {
-      ageControl.setValue(27.5);
-      expect(ageControl.valid).toBeFalsy();
-      expect(ageControl.hasError('pattern')).toBeTruthy();
+      it('should be fine with "27"', () => {
+        ageControl.setValue('27');
+        expect(ageControl.valid).toBeTruthy();
+      });
+
+      it('should fail on ages that are too low', () => {
+        ageControl.setValue('14');
+        expect(ageControl.valid).toBeFalsy();
+        expect(ageControl.hasError('min')).toBeTruthy();
+      });
+
+      // In the real world, you'd want to be pretty careful about
+      // setting upper limits on things like ages.
+      it('should fail on ages that are too high', () => {
+        ageControl.setValue(201);
+        expect(ageControl.valid).toBeFalsy();
+        // I have no idea why I have to use a lower case 'l' here
+        // when it's an upper case 'L' in `Validators.maxLength(2)`.
+        // But I apparently do.
+        expect(ageControl.hasError('max')).toBeTruthy();
+      });
+
+      it('should not allow an age to contain a decimal point', () => {
+        ageControl.setValue(27.5);
+        expect(ageControl.valid).toBeFalsy();
+        expect(ageControl.hasError('pattern')).toBeTruthy();
+      });
     });
   });
 

--- a/client/src/app/users/add-user.component.spec.ts
+++ b/client/src/app/users/add-user.component.spec.ts
@@ -133,9 +133,9 @@ describe('AddUserComponent', () => {
 
     describe('should be fine with "27"', () => {
       // Both the form control and the HTML itself enforce certain constraints
-      // what we can put in the age field. The HTML makes sure that the value
-      // is numeric, and the form control makes sure that it's in the right
-      // range.
+      // on what we can put in the age field. The HTML makes sure that the
+      // value is numeric, and the form control makes sure that it's in the
+      // right range.
       it('...the form control', () => {
         ageControl.setValue('27');
         expect(ageControl.valid).toBeTruthy();

--- a/client/src/app/users/add-user.component.spec.ts
+++ b/client/src/app/users/add-user.component.spec.ts
@@ -126,14 +126,27 @@ describe('AddUserComponent', () => {
       ageControl = addUserComponent.addUserForm.controls.age;
     });
 
-    it('should not allow empty names', () => {
+    it('should not allow empty ages', () => {
       ageControl.setValue('');
       expect(ageControl.valid).toBeFalsy();
     });
 
-    it('should be fine with "27"', () => {
-      ageControl.setValue('27');
-      expect(ageControl.valid).toBeTruthy();
+    describe('should be fine with "27"', () => {
+      // Both the form control and the HTML itself enforce certain constraints
+      // what we can put in the age field. The HTML makes sure that the value
+      // is numeric, and the form control makes sure that it's in the right
+      // range.
+      it('...the form control', () => {
+        ageControl.setValue('27');
+        expect(ageControl.valid).toBeTruthy();
+      });
+
+      it('...and the input field itself', () => {
+        const ageHtmlInput =
+          document.getElementsByTagName('input').namedItem('ageField');
+        ageHtmlInput.value = '27';
+        expect(ageHtmlInput.validity.valid).toBeTruthy();
+      });
     });
 
     it('should fail on ages that are too low', () => {
@@ -154,9 +167,13 @@ describe('AddUserComponent', () => {
     });
 
     it('should not allow an age to contain non-digits', () => {
-      ageControl.setValue('123x567');
-      expect(ageControl.valid).toBeFalsy();
-      expect(ageControl.hasError('pattern')).toBeTruthy();
+      // The HTML input field itself checks to make sure that the value is
+      // numeric. Angular's form controls aren't even involved with this step.
+      const ageHtmlInput =
+        document.getElementsByTagName('input').namedItem('ageField');
+      ageHtmlInput.value = '27aa';
+      expect(ageHtmlInput.validity.valid).toBeFalsy();
+      expect(ageHtmlInput.validity.valueMissing).toBeTruthy();
     });
   });
 

--- a/client/src/app/users/add-user.component.spec.ts
+++ b/client/src/app/users/add-user.component.spec.ts
@@ -171,6 +171,12 @@ describe('AddUserComponent', () => {
         expect(ageControl.hasError('min')).toBeTruthy();
       });
 
+      it('should fail on negative ages', () => {
+        ageControl.setValue('-27');
+        expect(ageControl.valid).toBeFalsy();
+        expect(ageControl.hasError('min')).toBeTruthy();
+      });
+
       // In the real world, you'd want to be pretty careful about
       // setting upper limits on things like ages.
       it('should fail on ages that are too high', () => {

--- a/client/src/app/users/add-user.component.spec.ts
+++ b/client/src/app/users/add-user.component.spec.ts
@@ -1,11 +1,10 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { FormsModule, NgForm, ReactiveFormsModule, FormGroup, AbstractControl } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule, FormGroup, AbstractControl } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { MockUserService } from 'src/testing/user.service.mock';
@@ -15,7 +14,6 @@ import { UserService } from './user.service';
 describe('AddUserComponent', () => {
   let addUserComponent: AddUserComponent;
   let addUserForm: FormGroup;
-  let calledClose: boolean;
   let fixture: ComponentFixture<AddUserComponent>;
 
   beforeEach(waitForAsync(() => {
@@ -39,7 +37,6 @@ describe('AddUserComponent', () => {
   }));
 
   beforeEach(() => {
-    calledClose = false;
     fixture = TestBed.createComponent(AddUserComponent);
     addUserComponent = fixture.componentInstance;
     addUserComponent.ngOnInit();

--- a/client/src/app/users/add-user.component.spec.ts
+++ b/client/src/app/users/add-user.component.spec.ts
@@ -101,12 +101,6 @@ describe('AddUserComponent', () => {
       expect(nameControl.hasError('maxlength')).toBeTruthy();
     });
 
-    it('should not allow a name to contain a symbol', () => {
-      nameControl.setValue('bad@email.com');
-      expect(nameControl.valid).toBeFalsy();
-      expect(nameControl.hasError('pattern')).toBeTruthy();
-    });
-
     it('should allow digits in the name', () => {
       nameControl.setValue('Bad2Th3B0ne');
       expect(nameControl.valid).toBeTruthy();

--- a/client/src/app/users/add-user.component.ts
+++ b/client/src/app/users/add-user.component.ts
@@ -72,7 +72,7 @@ export class AddUserComponent implements OnInit {
       // Since this is for a company, we need workers to be old enough to work, and probably not older than 200.
       age: new FormControl('', Validators.compose([
         Validators.required,
-        Validators.pattern('^[0-9]+[0-9]?'),
+        Validators.pattern('^[0-9]+$'),
         Validators.min(15),
         Validators.max(200),
       ])),

--- a/client/src/app/users/add-user.component.ts
+++ b/client/src/app/users/add-user.component.ts
@@ -27,7 +27,6 @@ export class AddUserComponent implements OnInit {
     ],
 
     age: [
-      {type: 'pattern', message: 'Age must be a number'},
       {type: 'min', message: 'Age must be at least 15'},
       {type: 'max', message: 'Age may not be greater than 200'},
       {type: 'required', message: 'Age is required'}
@@ -71,8 +70,10 @@ export class AddUserComponent implements OnInit {
 
       // Since this is for a company, we need workers to be old enough to work, and probably not older than 200.
       age: new FormControl('', Validators.compose([
+        // We don't need to check that the input is numeric, since we've set
+        // type="number" on the HTML. (The HTML will enforce that constraint
+        // for us.)
         Validators.required,
-        Validators.pattern('^[0-9]+$'),
         Validators.min(15),
         Validators.max(200),
       ])),

--- a/client/src/app/users/add-user.component.ts
+++ b/client/src/app/users/add-user.component.ts
@@ -23,7 +23,6 @@ export class AddUserComponent implements OnInit {
       {type: 'required', message: 'Name is required'},
       {type: 'minlength', message: 'Name must be at least 2 characters long'},
       {type: 'maxlength', message: 'Name cannot be more than 50 characters long'},
-      {type: 'pattern', message: 'Name must contain only numbers and letters'},
       {type: 'existingName', message: 'Name has already been taken'}
     ],
 
@@ -61,7 +60,6 @@ export class AddUserComponent implements OnInit {
         // very long names. This demonstrates that it's possible, though,
         // to have maximum length limits.
         Validators.maxLength(50),
-        Validators.pattern('^[A-Za-z0-9\\s]+[A-Za-z0-9\\s]+$(\\.0-9+)?'),
         (fc) => {
           if (fc.value.toLowerCase() === 'abc123' || fc.value.toLowerCase() === '123abc') {
             return ({existingName: true});

--- a/client/src/app/users/add-user.component.ts
+++ b/client/src/app/users/add-user.component.ts
@@ -27,9 +27,10 @@ export class AddUserComponent implements OnInit {
     ],
 
     age: [
+      {type: 'required', message: 'Age is required'},
       {type: 'min', message: 'Age must be at least 15'},
       {type: 'max', message: 'Age may not be greater than 200'},
-      {type: 'required', message: 'Age is required'}
+      {type: 'pattern', message: 'Age must be a whole number'}
     ],
 
     email: [
@@ -70,12 +71,13 @@ export class AddUserComponent implements OnInit {
 
       // Since this is for a company, we need workers to be old enough to work, and probably not older than 200.
       age: new FormControl('', Validators.compose([
-        // We don't need to check that the input is numeric, since we've set
-        // type="number" on the HTML. (The HTML will enforce that constraint
-        // for us.)
         Validators.required,
         Validators.min(15),
         Validators.max(200),
+        // In the HTML, we set type="number" on this field. That guarantees that the value of this field is numeric,
+        // but not that it's a whole number. (The user could still type -27.3232, for example.) So, we also need
+        // to include this pattern.
+        Validators.pattern('^[0-9]+$')
       ])),
 
       // We don't care much about what is in the company field, so we just add it here as part of the form


### PR DESCRIPTION
cf. #313 and UMM-CSci-3601/3601-lab4-mongo#35.

I've also changed a bit of how we're handling the age input, to make it clear what validation is coming from angular and what validation is coming from the HTML itself.

(TL;DR: We can rely on the HTML's built-in validation to check that the input is a number, but we have to add our own validation to check that the input is a _whole_ number.)

# Before

<img width="246" src="https://user-images.githubusercontent.com/56209343/108550312-06481880-72b4-11eb-959d-8be261d9d8a5.png">

<img width="235" src="https://user-images.githubusercontent.com/56209343/108570626-00622f80-72d4-11eb-9df4-b7ce4c97c757.png">

# After

<img width="233" src="https://user-images.githubusercontent.com/56209343/108550360-13650780-72b4-11eb-8a51-1f25ee19a3bd.png">

<img width="235" src="https://user-images.githubusercontent.com/56209343/108570487-a5c8d380-72d3-11eb-926b-3d0dd7c5ada9.png">


Closes #313.