### PR TITLE
Change the `POST /api/users/new` endpoint to just `POST /api/users`

### DIFF
--- a/client/src/app/users/user.service.spec.ts
+++ b/client/src/app/users/user.service.spec.ts
@@ -175,13 +175,13 @@ describe('User service: ', () => {
     expect(userService.filterUsers(testUsers, { name: userName, company: userCompany }).length).toBe(1);
   });
 
-  it('addUser() calls api/users/new', () => {
+  it('addUser() posts to api/users', () => {
 
     userService.addUser(testUsers[1]).subscribe(
       id => expect(id).toBe('testid')
     );
 
-    const req = httpTestingController.expectOne(userService.userUrl + '/new');
+    const req = httpTestingController.expectOne(userService.userUrl);
 
     expect(req.request.method).toEqual('POST');
     expect(req.request.body).toEqual(testUsers[1]);

--- a/client/src/app/users/user.service.ts
+++ b/client/src/app/users/user.service.ts
@@ -57,6 +57,6 @@ export class UserService {
 
   addUser(newUser: User): Observable<string> {
     // Send post request to add a new user with the user data as the body.
-    return this.httpClient.post<{id: string}>(this.userUrl + '/new', newUser).pipe(map(res => res.id));
+    return this.httpClient.post<{id: string}>(this.userUrl, newUser).pipe(map(res => res.id));
   }
 }

--- a/server/src/main/java/umm3601/Server.java
+++ b/server/src/main/java/umm3601/Server.java
@@ -68,7 +68,7 @@ public class Server {
 
     // Add new user with the user info being in the JSON body
     // of the HTTP request
-    server.post("/api/users/new", userController::addNewUser);
+    server.post("/api/users", userController::addNewUser);
 
     server.exception(Exception.class, (e, ctx) -> {
       ctx.status(500);

--- a/server/src/test/java/umm3601/user/UserControllerSpec.java
+++ b/server/src/test/java/umm3601/user/UserControllerSpec.java
@@ -279,7 +279,7 @@ public class UserControllerSpec {
     mockReq.setBodyContent(testNewUser);
     mockReq.setMethod("POST");
 
-    Context ctx = ContextUtil.init(mockReq, mockRes, "api/users/new");
+    Context ctx = ContextUtil.init(mockReq, mockRes, "api/users");
 
     userController.addNewUser(ctx);
 
@@ -308,7 +308,7 @@ public class UserControllerSpec {
     String testNewUser = "{\n\t\"name\": \"Test User\",\n\t\"age\":25,\n\t\"company\": \"testers\",\n\t\"email\": \"invalidemail\",\n\t\"role\": \"viewer\"\n}";
     mockReq.setBodyContent(testNewUser);
     mockReq.setMethod("POST");
-    Context ctx = ContextUtil.init(mockReq, mockRes, "api/users/new");
+    Context ctx = ContextUtil.init(mockReq, mockRes, "api/users");
 
     assertThrows(BadRequestResponse.class, () -> {
       userController.addNewUser(ctx);
@@ -320,7 +320,7 @@ public class UserControllerSpec {
     String testNewUser = "{\n\t\"name\": \"Test User\",\n\t\"age\":\"notanumber\",\n\t\"company\": \"testers\",\n\t\"email\": \"test@example.com\",\n\t\"role\": \"viewer\"\n}";
     mockReq.setBodyContent(testNewUser);
     mockReq.setMethod("POST");
-    Context ctx = ContextUtil.init(mockReq, mockRes, "api/users/new");
+    Context ctx = ContextUtil.init(mockReq, mockRes, "api/users");
 
     assertThrows(BadRequestResponse.class, () -> {
       userController.addNewUser(ctx);
@@ -332,7 +332,7 @@ public class UserControllerSpec {
     String testNewUser = "{\n\t\"age\":25,\n\t\"company\": \"testers\",\n\t\"email\": \"test@example.com\",\n\t\"role\": \"viewer\"\n}";
     mockReq.setBodyContent(testNewUser);
     mockReq.setMethod("POST");
-    Context ctx = ContextUtil.init(mockReq, mockRes, "api/users/new");
+    Context ctx = ContextUtil.init(mockReq, mockRes, "api/users");
 
     assertThrows(BadRequestResponse.class, () -> {
       userController.addNewUser(ctx);
@@ -344,7 +344,7 @@ public class UserControllerSpec {
     String testNewUser = "{\n\t\"name\": \"Test User\",\n\t\"age\":25,\n\t\"company\": \"testers\",\n\t\"email\": \"test@example.com\",\n\t\"role\": \"invalidrole\"\n}";
     mockReq.setBodyContent(testNewUser);
     mockReq.setMethod("POST");
-    Context ctx = ContextUtil.init(mockReq, mockRes, "api/users/new");
+    Context ctx = ContextUtil.init(mockReq, mockRes, "api/users");
 
     assertThrows(BadRequestResponse.class, () -> {
       userController.addNewUser(ctx);


### PR DESCRIPTION
Both on the client-side and server-side. 

This way, URLs are more like resources instead of actions. (Following RESTful API conventions.  😴💤)

Closes #317.