### PR TITLE
Comment that wildcard routes should go last

### DIFF
--- a/client/src/app/app-routing.module.ts
+++ b/client/src/app/app-routing.module.ts
@@ -5,7 +5,9 @@ import { UserListComponent } from './users/user-list.component';
 import { UserProfileComponent } from './users/user-profile.component';
 import { AddUserComponent } from './users/add-user.component';
 
-
+// Note that the 'users/new' route needs to come before 'users/:id'.
+// If 'users/:id' came first, it would accidentally catch requests to
+// 'users/new'; the router would just think that the string 'new' is a user ID.
 const routes: Routes = [
   {path: '', component: HomeComponent},
   {path: 'users', component: UserListComponent},


### PR DESCRIPTION
This was an issue that two different groups had this year. They had put a wildcard route (like `users/:id`) before a specific route (like `users/new`), making the specific route unreachable.

This PR adds a comment in `app-routing.module.ts` proactively explaining why that's an issue. 🙂