### PR TITLE
Remove bracket-pair-colorizer from extensions.json

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -16,10 +16,6 @@
     // https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig
     "EditorConfig.EditorConfig",
 
-    // Bracket Pair Colorizer 2
-    // https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer-2
-    "CoenraadS.bracket-pair-colorizer-2",
-
     // Gradle language support
     // https://marketplace.visualstudio.com/items?itemName=naco-siren.gradle-language
     "naco-siren.gradle-language",


### PR DESCRIPTION
Closes #594.

@floogulinc had suggested adding a note to the docs about how to turn on VS Code's own bracket colorizer. If you'd like, I could write such a note! But I haven't yet, because:

- I didn't really know where to put it
- There are already a _lot_ of instructions, and I didn't want to give the students more to read if I could avoid it
- VS Code has a zillion cool features and we don't have time to describe all of them :)

But if you feel like a note would be especially helpful, I can definitely add one! 🙂