### PR TITLE
Downgrade @types/node to v16.x.x

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -37,7 +37,7 @@
         "@cypress/schematic": "^1.6.0",
         "@floogulinc/cypress-mongo-seeder": "^1.1.1",
         "@types/jasmine": "^3.8.2",
-        "@types/node": "^17.0.21",
+        "@types/node": "^16.11.26",
         "@typescript-eslint/eslint-plugin": "^5.15.0",
         "@typescript-eslint/parser": "^5.15.0",
         "cypress": "^9.5.0",
@@ -53,7 +53,7 @@
         "karma-jasmine": "~4.0.1",
         "karma-jasmine-html-reporter": "^1.7.0",
         "ts-node": "^10.5.0",
-        "typescript": "^4.5.5"
+        "typescript": "~4.5.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3928,9 +3928,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "version": "16.11.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
+      "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -18169,9 +18169,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "version": "16.11.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
+      "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
       "dev": true
     },
     "@types/parse-json": {

--- a/client/package.json
+++ b/client/package.json
@@ -42,7 +42,7 @@
     "@cypress/schematic": "^1.6.0",
     "@floogulinc/cypress-mongo-seeder": "^1.1.1",
     "@types/jasmine": "^3.8.2",
-    "@types/node": "^17.0.21",
+    "@types/node": "^16.11.26",
     "@typescript-eslint/eslint-plugin": "^5.15.0",
     "@typescript-eslint/parser": "^5.15.0",
     "cypress": "^9.5.0",


### PR DESCRIPTION
As part of a mass upgrade, we accidentally bumped @types/node to v17, even though we're only using node 16. This PR downgrades @types/node back to v16.