### PR TITLE
Replace our use of JS string `+` with template literal

### DIFF
--- a/client/cypress/integration/add-user.spec.ts
+++ b/client/cypress/integration/add-user.spec.ts
@@ -105,7 +105,7 @@ describe('Add user', () => {
       cy.get('.user-card-email').should('have.text', user.email);
 
       // We should see the confirmation message at the bottom of the screen
-      cy.get('.mat-simple-snackbar').should('contain', `Added User ${user.name}`);
+      cy.get('.mat-simple-snackbar').should('contain', `Added user ${user.name}`);
     });
 
     it('Should fail with no company', () => {

--- a/client/src/app/users/add-user.component.ts
+++ b/client/src/app/users/add-user.component.ts
@@ -107,7 +107,7 @@ export class AddUserComponent implements OnInit {
   submitForm() {
     this.userService.addUser(this.addUserForm.value).subscribe(newID => {
       this.snackBar.open(
-        `Added User ${this.addUserForm.value.name}`,
+        `Added user ${this.addUserForm.value.name}`,
         null,
         { duration: 2000 }
       );

--- a/client/src/app/users/add-user.component.ts
+++ b/client/src/app/users/add-user.component.ts
@@ -106,9 +106,11 @@ export class AddUserComponent implements OnInit {
 
   submitForm() {
     this.userService.addUser(this.addUserForm.value).subscribe(newID => {
-      this.snackBar.open('Added User ' + this.addUserForm.value.name, null, {
-        duration: 2000,
-      });
+      this.snackBar.open(
+        `Added User ${this.addUserForm.value.name}`,
+        null,
+        { duration: 2000 }
+      );
       this.router.navigate(['/users/', newID]);
     }, err => {
       this.snackBar.open('Failed to add the user', 'OK', {

--- a/client/src/app/users/user.service.spec.ts
+++ b/client/src/app/users/user.service.spec.ts
@@ -150,7 +150,7 @@ describe('User service: ', () => {
       user => expect(user).toBe(targetUser)
     );
 
-    const expectedUrl: string = userService.userUrl + '/' + targetId;
+    const expectedUrl = `${userService.userUrl}/${targetId}`;
     const req = httpTestingController.expectOne(expectedUrl);
     expect(req.request.method).toEqual('GET');
     req.flush(targetUser);

--- a/client/src/app/users/user.service.ts
+++ b/client/src/app/users/user.service.ts
@@ -7,7 +7,7 @@ import { map } from 'rxjs/operators';
 
 @Injectable()
 export class UserService {
-  readonly userUrl: string = environment.apiUrl + 'users';
+  readonly userUrl: string = `${environment.apiUrl}users`;
 
   constructor(private httpClient: HttpClient) {
   }
@@ -31,7 +31,7 @@ export class UserService {
   }
 
   getUserById(id: string): Observable<User> {
-    return this.httpClient.get<User>(this.userUrl + '/' + id);
+    return this.httpClient.get<User>(`${this.userUrl}/${id}`);
   }
 
   filterUsers(users: User[], filters: { name?: string; company?: string }): User[] {


### PR DESCRIPTION
I'm just using VS Code's global search tool to look for +s in JS/TS code, and then convert them to use template literals.

The Karma tests didn't fail if I broke many of these, but the E2E tests did, which was nice since I forgot to switch to backticks at least once and actually broke things. The tests caught it, though, and I think this is good now.

Closes #836 