### PR TITLE
Update Java libraries

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -29,16 +29,16 @@ repositories {
 // External dependencies that our application utilizes
 dependencies {
   // Javalin, a simple web framework for Java
-  implementation 'io.javalin:javalin:4.4.0'
+  implementation 'io.javalin:javalin:4.5.0'
 
   // Mongo DB Driver for Java
-  implementation 'org.mongodb:mongodb-driver-sync:4.5.1'
+  implementation 'org.mongodb:mongodb-driver-sync:4.6.0'
 
   // Jackson, a JSON library for Java
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
 
   // MongoJack, MongoDB integration for Jackson
-  implementation 'org.mongojack:mongojack:4.3.0'
+  implementation 'org.mongojack:mongojack:4.5.0'
 
   // Jackson support modules for Java 8 datatypes
   implementation 'com.fasterxml.jackson.module:jackson-module-parameter-names:2.13.2'


### PR DESCRIPTION
This handles the three outstanding Dependabot updates for Java libraries. Since none of those Dependabot PRs ever got checked (because BetterCodeHub was having a bad day when they were created), I figured it would be easier to just do them in on new PR than force "fake" commits to each of the Dependabot PRs.

This updates:

* Javalin from 4.4.0 to 4.5.0
* mongodb-driver-sync from 4.5.1 to 4.6.0
* mongojack from 4.3.0 to 4.5.0

This should clear out three Dependabot PRs (#906, #907, and #908).