### PR TITLE
Dependancy fixes

### DIFF
--- a/client/.vscode/settings.json
+++ b/client/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "cSpell.words": [
-        "DATAGENE",
-        "KINETICUT",
-        "MOMENTIA",
-        "OHMNET"
-    ]
-}

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -37,7 +37,7 @@
         "@cypress/schematic": "^2.0.0",
         "@floogulinc/cypress-mongo-seeder": "^1.1.1",
         "@types/jasmine": "^4.0.3",
-        "@types/node": "^16.0.0",
+        "@types/node": "^16.11.43",
         "@typescript-eslint/eslint-plugin": "^5.29.0",
         "@typescript-eslint/parser": "^5.29.0",
         "cypress": "^10.3.0",
@@ -5091,9 +5091,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001363",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001363.tgz",
-      "integrity": "sha512-HpQhpzTGGPVMnCjIomjt+jvyUu8vNFo3TaDiZ/RcoTrlOq/5+tC8zHdsbgFB6MxmaY+jCpsH09aD80Bb4Ow3Sg==",
+      "version": "1.0.30001364",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001364.tgz",
+      "integrity": "sha512-9O0xzV3wVyX0SlegIQ6knz+okhBB5pE0PC40MNdwcipjwpxoUEHL24uJ+gG42cgklPjfO5ZjZPme9FTSN3QT2Q==",
       "dev": true,
       "funding": [
         {
@@ -5671,12 +5671,12 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.23.3",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.23.3.tgz",
-      "integrity": "sha512-WSzUs2h2vvmKsacLHNTdpyOC9k43AEhcGoFlVgCY4L7aw98oSBKtPL6vD0/TqZjRWRQYdDSLkzZIni4Crbbiqw==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.23.4.tgz",
+      "integrity": "sha512-RkSRPe+JYEoflcsuxJWaiMPhnZoFS51FcIxm53k4KzhISCBTmaGlto9dTIrYuk0hnJc3G6pKufAKepHnBq6B6Q==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.21.0",
+        "browserslist": "^4.21.1",
         "semver": "7.0.0"
       },
       "funding": {
@@ -6502,9 +6502,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.184",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.184.tgz",
-      "integrity": "sha512-IADi390FRdvxWfVX3hjzfTDNVHiTqVo9ar53/7em/SfhUG9YcjVhyQecY/XwmBHRKden/wFud7RWOUH7+7LFng==",
+      "version": "1.4.185",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.185.tgz",
+      "integrity": "sha512-9kV/isoOGpKkBt04yYNaSWIBn3187Q5VZRtoReq8oz5NY/A4XmU6cAoqgQlDp7kKJCZMRjWZ8nsQyxfpFHvfyw==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -19708,9 +19708,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001363",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001363.tgz",
-      "integrity": "sha512-HpQhpzTGGPVMnCjIomjt+jvyUu8vNFo3TaDiZ/RcoTrlOq/5+tC8zHdsbgFB6MxmaY+jCpsH09aD80Bb4Ow3Sg==",
+      "version": "1.0.30001364",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001364.tgz",
+      "integrity": "sha512-9O0xzV3wVyX0SlegIQ6knz+okhBB5pE0PC40MNdwcipjwpxoUEHL24uJ+gG42cgklPjfO5ZjZPme9FTSN3QT2Q==",
       "dev": true
     },
     "caseless": {
@@ -20134,12 +20134,12 @@
       }
     },
     "core-js-compat": {
-      "version": "3.23.3",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.23.3.tgz",
-      "integrity": "sha512-WSzUs2h2vvmKsacLHNTdpyOC9k43AEhcGoFlVgCY4L7aw98oSBKtPL6vD0/TqZjRWRQYdDSLkzZIni4Crbbiqw==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.23.4.tgz",
+      "integrity": "sha512-RkSRPe+JYEoflcsuxJWaiMPhnZoFS51FcIxm53k4KzhISCBTmaGlto9dTIrYuk0hnJc3G6pKufAKepHnBq6B6Q==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.21.0",
+        "browserslist": "^4.21.1",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -20752,9 +20752,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.184",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.184.tgz",
-      "integrity": "sha512-IADi390FRdvxWfVX3hjzfTDNVHiTqVo9ar53/7em/SfhUG9YcjVhyQecY/XwmBHRKden/wFud7RWOUH7+7LFng==",
+      "version": "1.4.185",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.185.tgz",
+      "integrity": "sha512-9kV/isoOGpKkBt04yYNaSWIBn3187Q5VZRtoReq8oz5NY/A4XmU6cAoqgQlDp7kKJCZMRjWZ8nsQyxfpFHvfyw==",
       "dev": true
     },
     "emoji-regex": {

--- a/client/package.json
+++ b/client/package.json
@@ -42,7 +42,7 @@
     "@cypress/schematic": "^2.0.0",
     "@floogulinc/cypress-mongo-seeder": "^1.1.1",
     "@types/jasmine": "^4.0.3",
-    "@types/node": "^16.0.0",
+    "@types/node": "^16.11.43",
     "@typescript-eslint/eslint-plugin": "^5.29.0",
     "@typescript-eslint/parser": "^5.29.0",
     "cypress": "^10.3.0",


### PR DESCRIPTION
This fixes a couple of small issues that snuck through in #1007:

* There was a spurious spelling file in `client` that this deletes.
* I had `"^16.0.0"` for the `@types/node` version in `package.json`, and to be consistent that should probably include the minor version, i.e., be "^16.11.43".

Thanks to @floogulinc for catching both of these.