### PR TITLE
Change Dependabot schedule for the client component to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,10 @@ updates:
 - package-ecosystem: npm
   directory: "/client"
   schedule:
-    interval: weekly
+    interval: monthly
     time: "12:00"
     timezone: America/Chicago
-  open-pull-requests-limit: 20
+  open-pull-requests-limit: 5
   ignore:
     - dependency-name: '@types/node'
       update-types:


### PR DESCRIPTION
This changes the interval for checking for updates to the client part of the project from weekly to monthly. I think we end up spending a lot of time chasing small updates when this updates weekly, and addressing changes once a month (and perhaps right before a semester starts) seems to be make a lot more sense.

I also changed the open pull requests limit from 20 to 5 for the client. In my experience updating things, I haven't used the PRs much for the client side of things, so having a bunch of them isn't really helpful.

I tend to follow @floogulinc's recommendation of using `ng update -C <packages>` since that automatically creates standardized commit messages. Then I use `npm outdated` to see what's left to update, and use `npm upgrade` to handle most of that. That all gets bundled up into a single "custom" PR and merged in as a bulk change.

So having 20 client PRs from Dependabot isn't really helpful. I'm hoping that 5 is enough that we can see that there's something to be done, which is all really need here.

Thoughts?