### PR TITLE
Add ng-update action

### DIFF
--- a/.github/workflows/ng-update.yml
+++ b/.github/workflows/ng-update.yml
@@ -1,4 +1,4 @@
-name: "Update Angular Action"
+name: "Update Angular"
 on: # when the action should run. Can also be a CRON or in response to external events. see https://git.io/JeBz1
   schedule:
     - cron: '0 5 1 * *'

--- a/.github/workflows/ng-update.yml
+++ b/.github/workflows/ng-update.yml
@@ -2,6 +2,7 @@ name: "Update Angular Action"
 on: # when the action should run. Can also be a CRON or in response to external events. see https://git.io/JeBz1
   schedule:
     - cron: '0 5 1 * *'
+  workflow_dispatch:
 
 jobs:
   ngxUptodate:

--- a/.github/workflows/ng-update.yml
+++ b/.github/workflows/ng-update.yml
@@ -1,0 +1,13 @@
+name: "Update Angular Action"
+on: # when the action should run. Can also be a CRON or in response to external events. see https://git.io/JeBz1
+  schedule:
+    - cron: '0 5 1 * *'
+
+jobs:
+  ngxUptodate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Updating ng dependencies # the magic happens here !
+        uses: fast-facts/ng-update@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
@floogulinc suggested that we try [the `ngxUptodate` action](https://github.com/fast-facts/ng-update) again. Hopefully this will run on the first day of every month, and create a PR that updates all the Angular libraries that are ready for updates.

If this works, it might make sense to run this more often (weekly?) since we'll be able to just approve the PRs that it generates and not hassle everyone with the need for code reviews.