### PR TITLE
Change ng-update GitHub Action to act on `main` branch

### DIFF
--- a/.github/workflows/ng-update.yml
+++ b/.github/workflows/ng-update.yml
@@ -11,4 +11,5 @@ jobs:
       - name: Updating ng dependencies # the magic happens here !
         uses: fast-facts/ng-update@v1.0.0
         with:
+          base-branch: main
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This action defaults to acting on `master`, which doesn't work for us. This adds a config line that tells it to act on `main` instead.