### PR TITLE
1411 upgrade to java v21 lts

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -78,7 +78,7 @@ jacocoTestReport {
     // This isn't strictly necessary, but the default reports
     // location is buried pretty deep in the build directory,
     // so this makes it easier to find.
-    html.destination file("${buildDir}/jacocoHtml")
+    html.outputLocation = file("${buildDir}/jacocoHtml")
   }
 
   afterEvaluate {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -12,10 +12,10 @@ plugins {
   id 'checkstyle'
 }
 
-// Build and run the project with Java 11
+// Build and run the project with Java 21
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(11)
+    languageVersion = JavaLanguageVersion.of(21)
   }
 }
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -46,6 +46,9 @@ dependencies {
   // JUnit Jupiter Engine for testing.
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.1'
 
+  // JUnit Platform Launcher for testing.
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
   // Mockito for testing
   testImplementation 'org.mockito:mockito-core:5.8.0'
 

--- a/server/settings.gradle
+++ b/server/settings.gradle
@@ -6,6 +6,13 @@
  * Detailed information about configuring a multi-project build in Gradle can be found
  * in the user manual at https://docs.gradle.org/5.6/userguide/multi_project_builds.html
  */
+// This allows us to use the jresolver plugin. If we have
+// this plugin in place, we can specify a particular JDK version
+// in `build.gradle` and Gradle will download it for us if it's
+// not already installed on the system. This will hopefully make
+// it easier for people to run the project on a broad range of
+// computers without having to worry about installing the right
+// JDK version.
 
 plugins {
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.7.0'


### PR DESCRIPTION
From issue #1411 -
"We're currently specifying v11 in build.gradle, which is super old now. It's easy to fix in the build.gradle file; see https://github.com/UMM-CSci-3601/intro-to-git/pull/115 for how it was handled in the first lab."

Closes #1411

Since that PR involved also upgrading Gradle, there were a couple of other things I wanted to be sure to include here, but I'm not certain they are working in the same way.