### PR TITLE
1452 Deal with large bundle size issues

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -50,7 +50,7 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "2mb",
+                  "maximumWarning": "4mb",
                   "maximumError": "5mb"
                 },
                 {

--- a/client/angular.json
+++ b/client/angular.json
@@ -15,12 +15,14 @@
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:browser",
+          "builder": "@angular-devkit/build-angular:application",
           "options": {
             "outputPath": "dist/client",
             "index": "src/index.html",
-            "main": "src/main.ts",
-            "polyfills": "zone.js",
+            "browser": "src/main.ts",
+            "polyfills": [
+              "zone.js"
+            ],
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": [
@@ -31,9 +33,7 @@
               "src/styles.scss"
             ],
             "scripts": [],
-            "vendorChunk": true,
             "extractLicenses": false,
-            "buildOptimizer": false,
             "sourceMap": true,
             "optimization": false,
             "namedChunks": true
@@ -61,9 +61,7 @@
               ]
             },
             "development": {
-              "buildOptimizer": false,
               "optimization": false,
-              "vendorChunk": true,
               "extractLicenses": false,
               "sourceMap": true,
               "namedChunks": true


### PR DESCRIPTION
When working on a different PR, we noticed that our bundle size started exceeding the budget (#1452). 

It occurred to me that it might be due to changes involved with upgrading to Angular 17. There is some information about a new builder that this PR integrates that significantly reduces the size of our bundle. [Using the application builder](https://angular.io/guide/esbuild#using-the-application-builder) significantly reduces the size of our bundle.

There may be other things to consider that are not addressed here, but this PR gets us below the error level. I also changed the budget for the initial bundle to be 4mb so we would not get a warning every time we build. We may want to do some other optimizations to fully address the issue, but I think that this PR closes #1452.
