### PR TITLE
Broaden workflow triggers

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -1,6 +1,10 @@
 name: Client
 
-on: [push]
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 defaults:
   run:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,6 +1,10 @@
 name: End-to-End
 
-on: [push]
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 jobs:
   ng-e2e:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -1,6 +1,10 @@
 name: Server
 
-on: [push]
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
 
 jobs:
   gradle-build:


### PR DESCRIPTION
I think that the simple `on: [push]` that I used doesn't work if there is a pull request from a fork. This changes all the client and server test workflows to use the same configuration as the CodeQL configuration in the hopes that this gets things to work for us.