### PR TITLE
Use AJV to validate `User` JSON when getting a `User` by ID

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -19,6 +19,7 @@
         "@angular/platform-browser": "^17.0.9",
         "@angular/platform-browser-dynamic": "^17.0.9",
         "@angular/router": "^17.0.9",
+        "ajv": "^8.12.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.4.0",
         "zone.js": "~0.14.3"

--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
     "@angular/platform-browser": "^17.0.9",
     "@angular/platform-browser-dynamic": "^17.0.9",
     "@angular/router": "^17.0.9",
+    "ajv": "^8.12.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.4.0",
     "zone.js": "~0.14.3"

--- a/client/src/app/users/user-role.ts
+++ b/client/src/app/users/user-role.ts
@@ -1,0 +1,7 @@
+import { JTDSchemaType } from "ajv/dist/jtd";
+
+export type UserRole = 'admin' | 'editor' | 'viewer';
+
+export const userRoleSchema: JTDSchemaType<UserRole> = {
+  enum: ["admin", "editor", "viewer"]
+};

--- a/client/src/app/users/user.ts
+++ b/client/src/app/users/user.ts
@@ -1,5 +1,8 @@
+import Ajv, { JTDSchemaType } from "ajv/dist/jtd";
+import { UserRole, userRoleSchema } from "./user-role";
+
 export interface User {
-  _id: string;
+  _id?: string;
   name: string;
   age: number;
   company: string;
@@ -8,4 +11,19 @@ export interface User {
   role: UserRole;
 }
 
-export type UserRole = 'admin' | 'editor' | 'viewer';
+const userSchema: JTDSchemaType<User> = {
+  properties: {
+    name: {type: "string"},
+    age: {type: "uint8"},
+    company: {type: "string"},
+    email: {type: "string"},
+    role: userRoleSchema
+  },
+  optionalProperties: {
+    _id: {type: "string"},
+    avatar: {type: "string"},
+  }
+}
+
+const ajv = new Ajv()
+export const validateUser = ajv.compile(userSchema)

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -15,7 +15,10 @@
       "es2020",
       "dom"
     ],
-    "useDefineForClassFields": false
+    "useDefineForClassFields": false,
+    "strictNullChecks": true,
+    // "strict": true,
+    "noImplicitAny": true
   },
   "exclude": ["./cypress.config.ts"],
   "angularCompilerOptions": {


### PR DESCRIPTION
This PR introduces [the AJV library](https://ajv.js.org/), which we can use to validate JSON objects, i.e., confirm that they have all the right fields. At the moment, for example, the server could send any kind of weird stuff back when we request a `User`, and the Angular code never really checks that or generates a meaningful error.

This PR should be considered the start of a process, only checking one specific case, namely checking that the object `UserService#getUserById` receives from the HTTP request is actually an instance of the `User` type. If we merge this in, we would then want to do create issues for additional validation. 

- [ ] Anything that comes from the server via an HTTP request should be validated
- [ ] Anything that comes from a form (i.e., from user input) should be validated
   - This second one is arguably less necessary since we've got lots of validation on the form for adding a new user, but it's still probably a good idea.

The "important" parts of this PR are:

- Adding a dependency on `ajv`
- Adding `"strictNullChecks": true` in `tsconfig.json`
   - This is needed for `ajv` to work; without it AJV can't tell properly distinguish between required and optional fields (I think).
- Adding a JSON schema to `user.ts`
- Adding a JSON schema to `user-role.ts`
   - We ended up pulling `UserRole` out into its own file while we were here