### PR TITLE
Fix control flow migration oddities

### DIFF
--- a/client/src/app/users/user-card.component.html
+++ b/client/src/app/users/user-card.component.html
@@ -35,12 +35,10 @@
         </mat-list>
       </mat-card-content>
     }
-    @if (this.simple) {
-      <mat-card-actions>
-        @if (this.simple) {
-          <button mat-button data-test="viewProfileButton" [routerLink]="['/users', this.user._id]">View Profile</button>
-        }
-      </mat-card-actions>
-    }
+    <mat-card-actions>
+      @if (this.simple) {
+        <button mat-button data-test="viewProfileButton" [routerLink]="['/users', this.user._id]">View Profile</button>
+      }
+    </mat-card-actions>
   </mat-card>
 }

--- a/client/src/app/users/user-card.component.html
+++ b/client/src/app/users/user-card.component.html
@@ -35,10 +35,10 @@
         </mat-list>
       </mat-card-content>
     }
-    <mat-card-actions>
-      @if (this.simple) {
+    @if (this.simple) {
+      <mat-card-actions>
         <button mat-button data-test="viewProfileButton" [routerLink]="['/users', this.user._id]">View Profile</button>
-      }
-    </mat-card-actions>
-  </mat-card>
+      </mat-card-actions>
+    }
+</mat-card>
 }

--- a/client/src/app/users/user-list.component.html
+++ b/client/src/app/users/user-list.component.html
@@ -70,7 +70,7 @@
             <!-- Card grid view -->
             @case ('card') {
               <div class="user-cards-container flex-row gap-8 flex-wrap">
-                @for (user of filteredUsers; track user) {
+                @for (user of filteredUsers; track user._id) {
                   <app-user-card [simple]="true" class="user-card" [user]="user" ></app-user-card>
                 }
               </div>
@@ -81,7 +81,7 @@
                 <mat-card-content>
                   <mat-nav-list class="user-nav-list">
                     <h3 mat-subheader>Users</h3>
-                    @for (user of this.filteredUsers; track user) {
+                    @for (user of this.filteredUsers; track user._id) {
                       <a mat-list-item [routerLink]="['/users', user._id]" class="user-list-item">
                         @if (this.user.avatar) {
                           <img matListItemAvatar [src]="user.avatar" alt="Avatar for {{ user.name }}">


### PR DESCRIPTION
I've noticed a few odd bits that I think resulted from running the automated control flow migration tool. 

- [x] We want to track `user._id`, not `user` in `@for` loops
- [x] There are two nested instances of `@if (this.simple)` in `UserCardComponent` HTML

This fixes these issues.

Fixes #1480 