### PR TITLE
Fix deployment issue

### DIFF
--- a/client/angular.json
+++ b/client/angular.json
@@ -15,11 +15,11 @@
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:application",
+          "builder": "@angular-devkit/build-angular:browser",
           "options": {
             "outputPath": "dist/client",
             "index": "src/index.html",
-            "browser": "src/main.ts",
+            "main": "src/main.ts",
             "polyfills": [
               "zone.js"
             ],


### PR DESCRIPTION
When I build the project on the droplet, all I ever get is 404 errors. I ended up doing a complex version of `git bisect` only working on PR merges, and finally narrowed it down to #1453 ("Deal with large bundle sizes"). As well as upping the budget for bundle sizes, that PR changed from using the `browser` builder to the `application` builder. That's worked fine in development, but seems to fail in deployment.

This should fix the deployment problem. I'm not honestly sure why changing the builder matters, but based on way too much fiddling on the droplet, I think this will fix problem.