### PR TITLE
Replace construct-based injection with `inject()` calls

### DIFF
--- a/client/src/app/company-list/company-list.component.ts
+++ b/client/src/app/company-list/company-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, Signal } from '@angular/core';
+import { Component, inject, Signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { CompanyCardComponent } from '../company-card/company-card.component';
 import { UserService } from '../users/user.service';
@@ -12,9 +12,7 @@ import { Company } from './company';
   styleUrl: './company-list.component.scss'
 })
 export class CompanyListComponent {
-  companies: Signal<Company[]>;
+  private userService = inject(UserService);
 
-  constructor(private userService: UserService) {
-    this.companies = toSignal(this.userService.getCompanies());
-  }
+  companies: Signal<Company[]> = toSignal(this.userService.getCompanies());
 }

--- a/client/src/app/users/add-user.component.ts
+++ b/client/src/app/users/add-user.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -19,6 +19,9 @@ import { UserService } from './user.service';
     imports: [FormsModule, ReactiveFormsModule, MatCardModule, MatFormFieldModule, MatInputModule, MatSelectModule, MatOptionModule, MatButtonModule]
 })
 export class AddUserComponent {
+  private userService = inject(UserService);
+  private snackBar = inject(MatSnackBar);
+  private router = inject(Router);
 
   addUserForm = new FormGroup({
     // We allow alphanumeric input and limit the length for name.
@@ -67,7 +70,6 @@ export class AddUserComponent {
     ])),
   });
 
-
   // We can only display one error at a time,
   // the order the messages are defined in is the order they will display in.
   readonly addUserValidationMessages = {
@@ -95,12 +97,6 @@ export class AddUserComponent {
       { type: 'pattern', message: 'Role must be Admin, Editor, or Viewer' },
     ]
   };
-
-  constructor(
-    private userService: UserService,
-    private snackBar: MatSnackBar,
-    private router: Router) {
-  }
 
   formControlHasError(controlName: string): boolean {
     return this.addUserForm.get(controlName).invalid &&

--- a/client/src/app/users/user-list.component.ts
+++ b/client/src/app/users/user-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -37,6 +37,9 @@ import { UserService } from './user.service';
 })
 
 export class UserListComponent implements OnInit, OnDestroy  {
+  private userService = inject(UserService);
+  private snackBar = inject(MatSnackBar);
+
   // These are public so that tests can reference them (.spec.ts)
   public serverFilteredUsers: User[];
   public filteredUsers: User[];
@@ -49,19 +52,6 @@ export class UserListComponent implements OnInit, OnDestroy  {
 
   errMsg = '';
   private ngUnsubscribe = new Subject<void>();
-
-
-  /**
-   * This constructor injects both an instance of `UserService`
-   * and an instance of `MatSnackBar` into this component.
-   * `UserService` lets us interact with the server.
-   *
-   * @param userService the `UserService` used to get users from the server
-   * @param snackBar the `MatSnackBar` used to display feedback
-   */
-  constructor(private userService: UserService, private snackBar: MatSnackBar) {
-    // Nothing here – everything is in the injection parameters.
-  }
 
   /**
    * Get the users from the server, filtered by the role and age specified

--- a/client/src/app/users/user-profile.component.ts
+++ b/client/src/app/users/user-profile.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute, ParamMap } from '@angular/router';
@@ -16,6 +16,10 @@ import { UserService } from './user.service';
     imports: [UserCardComponent, MatCardModule]
 })
 export class UserProfileComponent implements OnInit, OnDestroy {
+  private snackBar = inject(MatSnackBar);
+  private route = inject(ActivatedRoute);
+  private userService = inject(UserService);
+
   user: User;
   error: { help: string, httpResponse: string, message: string };
 
@@ -24,8 +28,6 @@ export class UserProfileComponent implements OnInit, OnDestroy {
   // destroyed. That can be used ot tell any subscriptions to
   // terminate, allowing the system to free up their resources (like memory).
   private ngUnsubscribe = new Subject<void>();
-
-  constructor(private snackBar: MatSnackBar, private route: ActivatedRoute, private userService: UserService) { }
 
   ngOnInit(): void {
     // The `map`, `switchMap`, and `takeUntil` are all RXJS operators, and


### PR DESCRIPTION
This replaces _most_ of the construct-based injection with `inject()` calls. The few remaining injectors are tied up with `ActivatedRoute` and the now deprecated `RouterTestingModule`. I think those can't be fixed without addressing that issue (#1581).

This makes progress on #1416, but doesn't entirely finish it.