### PR TITLE
Bump the add user timeout to 5 full minutes

### DIFF
--- a/client/cypress/e2e/add-user.cy.ts
+++ b/client/cypress/e2e/add-user.cy.ts
@@ -118,10 +118,10 @@ describe('Add user', () => {
       cy.wait('@addUser');
 
       // New URL should end in the 24 hex character Mongo ID of the newly added user.
-      // We'll wait up to 10 seconds for this these `should()` assertions to succeed.
+      // We'll wait up to five full minutes for this these `should()` assertions to succeed.
       // Hopefully that long timeout will help ensure that our Cypress tests pass in
       // GitHub Actions, where we're often running on slow VMs.
-      cy.url({ timeout: 10000 })
+      cy.url({ timeout: 300000 })
         .should('match', /\/users\/[0-9a-fA-F]{24}$/)
         .should('not.match', /\/users\/new$/);
 


### PR DESCRIPTION
We keep having issues (which I assume are timeouts) in our Cypress tests for adding a user when they run in GitHub Actions. This takes the rather extreme approach of allowing up to _five_ full minutes on those assertions in the hopes that this stops that flakiness in our tests.