### PR TITLE
Add a 30 sec timeout to seeding the DB in Cypress tests

### DIFF
--- a/client/cypress/e2e/add-user.cy.ts
+++ b/client/cypress/e2e/add-user.cy.ts
@@ -80,7 +80,8 @@ describe('Add user', () => {
 
   describe('Adding a new user', () => {
     beforeEach(() => {
-      cy.task('seed:database');
+      // Wait up to 30 seconds for the seeding to complete.
+      cy.task('seed:database', null, { timeout: 30000 } );
     });
 
     it('Should go to the right page, and have the right info', () => {

--- a/client/cypress/e2e/company-list.cy.ts
+++ b/client/cypress/e2e/company-list.cy.ts
@@ -5,7 +5,8 @@ const page = new CompanyListPage();
 describe('Company list', () => {
 
   before(() => {
-    cy.task('seed:database');
+      // Wait up to 30 seconds for the seeding to complete.
+      cy.task('seed:database', null, { timeout: 30000 } );
   });
 
   beforeEach(() => {

--- a/client/cypress/e2e/user-list.cy.ts
+++ b/client/cypress/e2e/user-list.cy.ts
@@ -5,7 +5,8 @@ const page = new UserListPage();
 describe('User list', () => {
 
   before(() => {
-    cy.task('seed:database');
+      // Wait up to 30 seconds for the seeding to complete.
+      cy.task('seed:database', null, { timeout: 30000 } );
   });
 
   beforeEach(() => {

--- a/client/cypress/plugins/index.ts
+++ b/client/cypress/plugins/index.ts
@@ -19,6 +19,9 @@ const mongoDb = process.env.MONGO_DB || 'dev';
 const mongoUri = `mongodb://${mongoHost}/${mongoDb}`;
 const dbSeedDir = '../database/seed';
 
+// We're not using `_config` anywhere, so it's OK that it's not
+// used.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const pluginConfig: Cypress.PluginConfig = (on, _config) => {
   // `on` is used to hook into various events Cypress emits
   // `_config` is the resolved Cypress config


### PR DESCRIPTION
This adds a 30 second timeout to the DB seeding in all the relevant Cypress tests. I'm hoping this will reduce the flakiness of our E2E tests.